### PR TITLE
PaysScript uses staking credential

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,8 +15,8 @@ package cardano-crypto-praos
 
 source-repository-package
   type: git
-  location: https://github.com/etiennejf/plutus-apps.git
-  tag: faa90fe151b7dbf76fe81d8893714acfd2aa298e
+  location: https://github.com/j-mueller/plutus-apps.git
+  tag: 1a0580e00994dd826e8ac20c930992ba3ca40060
   subdir:
     freer-extras
     pab-blockfrost

--- a/cooked-validators/src/Cooked/Attack/DatumHijacking.hs
+++ b/cooked-validators/src/Cooked/Attack/DatumHijacking.hs
@@ -43,12 +43,12 @@ datumHijackingAttack change select mcst skel =
   let thief = datumHijackingTarget @a
 
       changeRecipient :: PaysScriptConstraint -> Maybe PaysScriptConstraint
-      changeRecipient (PaysScriptConstraint val dat money) =
+      changeRecipient (PaysScriptConstraint val dat stak money) =
         -- checks whether val _is of the same type as_ the thief, they're obviously different scripts.
         case val ~*~? thief of
           Just HRefl ->
             if change val dat money
-              then Just $ PaysScriptConstraint thief dat money
+              then Just $ PaysScriptConstraint thief dat stak money
               else Nothing
           Nothing -> Nothing
    in addLabel (DatumHijackingLbl $ L.validatorAddress thief)

--- a/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Pretty.hs
@@ -44,8 +44,8 @@ prettyWallet pkh =
     phash = prettyHash pkh
 
 prettyOutConstraint :: OutConstraint -> Doc ann
-prettyOutConstraint (PaysScript val datum value) =
-  prettyEnum ("PaysScript" <+> prettyTypedValidator val) "-" (map (uncurry (prettyDatumVal val)) [(datum, value)])
+prettyOutConstraint (PaysScript val datum stk value) =
+  prettyEnum ("PaysScript" <+> prettyTypedValidator val <> maybe mempty (\k -> "StakePKH:" <+> PP.pretty k) stk) "-" (map (uncurry (prettyDatumVal val)) [(datum, value)])
 prettyOutConstraint (PaysPKWithDatum pkh stak dat val) =
   prettyEnum
     ("PaysPK" <+> prettyWallet pkh)

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -170,6 +170,7 @@ data OutConstraint where
     (PaysScriptConstrs a) =>
     Pl.TypedValidator a ->
     Pl.DatumType a ->
+    Maybe Pl.StakingCredential ->
     Pl.Value ->
     OutConstraint
   -- | Creates a UTxO to a specific 'Pl.PubKeyHash' with a potential 'Pl.StakePubKeyHash'.
@@ -188,9 +189,9 @@ data OutConstraint where
 -- NB don't forget to update the Eq instance when adding new constructors
 
 instance Eq OutConstraint where
-  PaysScript s1 d1 v1 == PaysScript s2 d2 v2 =
+  PaysScript s1 d1 st1 v1 == PaysScript s2 d2 st2 v2 =
     case s1 ~*~? s2 of
-      Just HRefl -> (s1, v1) == (s2, v2) && d1 Pl.== d2
+      Just HRefl -> (s1, v1) == (s2, v2) && d1 Pl.== d2  && st1 == st2
       Nothing -> False
   PaysPKWithDatum pk1 stake1 d1 v1 == PaysPKWithDatum pk2 stake2 d2 v2 =
     case d1 ~*~? d2 of

--- a/cooked-validators/src/Example.hs
+++ b/cooked-validators/src/Example.hs
@@ -70,7 +70,7 @@ payEndpoint amountToPk amountToScript = do
     validateTxSkel def $
       txSkel
         [ paysPK (walletPKHash $ wallet 2) (Pl.lovelaceValueOf amountToPk),
-          PaysScript aValidator ADatum (Pl.lovelaceValueOf amountToScript)
+          PaysScript aValidator ADatum Nothing (Pl.lovelaceValueOf amountToScript)
         ]
   spOuts <- spOutsFromCardanoTx cardanoTx
   -- We return the second (index 1) utxo from the transaction outputs:


### PR DESCRIPTION
Make it possible to specify a staking credential in the `PaysScript` tx out constraint

This depends on https://github.com/etiennejf/plutus-apps/pull/25