### PR TITLE
Switch to patched cardano-api with memoised toBabbagePParams

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -178,8 +178,8 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/input-output-hk/cardano-node
-  tag: 1.35.3
+  location: https://github.com/steshaw/cardano-node
+  tag: 94fc6e14f72880e6b542e582d6796f3aff695a00
   subdir:
     cardano-api
     cardano-cli


### PR DESCRIPTION
The commit was done on top of 1.35.3.
See https://github.com/steshaw/cardano-node/tree/memoise-to-pparams.