### PR TITLE
Patch utxoSuchThat to consider addressCredential only

### DIFF
--- a/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
+++ b/cooked-validators/src/Cooked/MockChain/Monad/Direct.hs
@@ -342,7 +342,7 @@ utxosSuchThat' ::
   MockChainT m [(SpendableOut, Maybe a)]
 utxosSuchThat' addr datumPred = do
   ix <- gets (Pl.getIndex . mcstIndex)
-  let ix' = M.filter ((== addr) . Pl.txOutAddress) ix
+  let ix' = M.filter ((== Pl.addressCredential addr) . Pl.addressCredential . Pl.txOutAddress) ix
   mapMaybe (fmap assocl . rstr) <$> mapM (\(oref, out) -> (oref,) <$> go oref out) (M.toList ix')
   where
     go :: Pl.TxOutRef -> Pl.TxOut -> MockChainT m (Maybe (Pl.ChainIndexTxOut, Maybe a))

--- a/cooked-validators/src/Cooked/Tx/Constraints.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints.hs
@@ -117,13 +117,14 @@ instance ToLedgerConstraint OutConstraint where
         -- use of this constraint to properly add entry in datum witness map.
         -- TODO: need to enrich PaysScript constraint to consider only datumHash (datum not added in map),
         -- DatumInTx and InlineDatum
-        
-        Pl.singleton (Pl.MustPayToAddress
-          addr
-          (Just (Pl.TxOutDatumInTx (Pl.Datum $ Pl.toBuiltinData datum)))
-          Nothing
-          value
-        )
+
+        Pl.singleton
+          ( Pl.MustPayToAddress
+              addr
+              (Just (Pl.TxOutDatumInTx (Pl.Datum $ Pl.toBuiltinData datum)))
+              Nothing
+              value
+          )
 
 instance ToLedgerConstraint Constraints where
   extractDatumStr (miscConstraints :=>: outConstraints) =

--- a/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
+++ b/cooked-validators/src/Cooked/Tx/Constraints/Type.hs
@@ -191,7 +191,7 @@ data OutConstraint where
 instance Eq OutConstraint where
   PaysScript s1 d1 st1 v1 == PaysScript s2 d2 st2 v2 =
     case s1 ~*~? s2 of
-      Just HRefl -> (s1, v1) == (s2, v2) && d1 Pl.== d2  && st1 == st2
+      Just HRefl -> (s1, v1) == (s2, v2) && d1 Pl.== d2 && st1 == st2
       Nothing -> False
   PaysPKWithDatum pk1 stake1 d1 v1 == PaysPKWithDatum pk2 stake2 d2 v2 =
     case d1 ~*~? d2 of

--- a/cooked-validators/tests/Cooked/AttackSpec/DatumHijacking.hs
+++ b/cooked-validators/tests/Cooked/AttackSpec/DatumHijacking.hs
@@ -61,7 +61,7 @@ lockTxSkel :: SpendableOut -> L.TypedValidator MockContract -> TxSkel
 lockTxSkel o v =
   txSkelOpts
     (def {adjustUnbalTx = True})
-    ([SpendsPK o] :=>: [PaysScript v FirstLock lockValue])
+    ([SpendsPK o] :=>: [PaysScript v FirstLock Nothing lockValue])
 
 txLock :: MonadBlockChain m => L.TypedValidator MockContract -> m ()
 txLock v = do
@@ -74,7 +74,7 @@ relockTxSkel v o =
   txSkelOpts
     (def {adjustUnbalTx = True})
     ( [SpendsScript v () o]
-        :=>: [PaysScript v SecondLock lockValue]
+        :=>: [PaysScript v SecondLock Nothing lockValue]
     )
 
 txRelock ::
@@ -156,11 +156,11 @@ tests =
             x3 = L.lovelaceValueOf 9999
             skelIn =
               txSkel
-                [ PaysScript val1 SecondLock x1,
-                  PaysScript val1 SecondLock x3,
-                  PaysScript val2 SecondLock x1,
-                  PaysScript val1 FirstLock x2,
-                  PaysScript val1 SecondLock x2
+                [ PaysScript val1 SecondLock Nothing x1,
+                  PaysScript val1 SecondLock Nothing x3,
+                  PaysScript val2 SecondLock Nothing x1,
+                  PaysScript val1 FirstLock Nothing x2,
+                  PaysScript val1 SecondLock Nothing x2
                 ]
             skelOut select =
               datumHijackingAttack @MockContract
@@ -175,11 +175,11 @@ tests =
             skelExpected a b =
               txSkelLbl
                 (DatumHijackingLbl $ L.validatorAddress thief)
-                [ PaysScript val1 SecondLock x1,
-                  PaysScript a SecondLock x3,
-                  PaysScript val2 SecondLock x1,
-                  PaysScript val1 FirstLock x2,
-                  PaysScript b SecondLock x2
+                [ PaysScript val1 SecondLock Nothing x1,
+                  PaysScript a SecondLock Nothing x3,
+                  PaysScript val2 SecondLock Nothing x1,
+                  PaysScript val1 FirstLock Nothing x2,
+                  PaysScript b SecondLock Nothing x2
                 ]
          in assertSameTxSkels [skelExpected thief val1] (skelOut (0 ==))
               .&&. assertSameTxSkels [skelExpected val1 thief] (skelOut (1 ==))

--- a/cooked-validators/tests/Cooked/AttackSpec/DoubleSat.hs
+++ b/cooked-validators/tests/Cooked/AttackSpec/DoubleSat.hs
@@ -115,13 +115,13 @@ dsTestMockChainSt = case runMockChainRaw def def setup of
   Right (_, mcst) -> mcst
   where
     setup = do
-      validateTxSkel def $ txSkel [PaysScript aValidator ADatum (L.lovelaceValueOf 2_000_000)]
-      validateTxSkel def $ txSkel [PaysScript aValidator ADatum (L.lovelaceValueOf 3_000_000)]
-      validateTxSkel def $ txSkel [PaysScript aValidator ADatum (L.lovelaceValueOf 4_000_000)]
-      validateTxSkel def $ txSkel [PaysScript aValidator ADatum (L.lovelaceValueOf 5_000_000)]
-      validateTxSkel def $ txSkel [PaysScript bValidator BDatum (L.lovelaceValueOf 6_000_000)]
-      validateTxSkel def $ txSkel [PaysScript bValidator BDatum (L.lovelaceValueOf 7_000_000)]
-      validateTxSkel def $ txSkel [PaysScript bValidator BDatum (L.lovelaceValueOf 8_000_000)]
+      validateTxSkel def $ txSkel [PaysScript aValidator ADatum Nothing (L.lovelaceValueOf 2_000_000)]
+      validateTxSkel def $ txSkel [PaysScript aValidator ADatum Nothing (L.lovelaceValueOf 3_000_000)]
+      validateTxSkel def $ txSkel [PaysScript aValidator ADatum Nothing (L.lovelaceValueOf 4_000_000)]
+      validateTxSkel def $ txSkel [PaysScript aValidator ADatum Nothing (L.lovelaceValueOf 5_000_000)]
+      validateTxSkel def $ txSkel [PaysScript bValidator BDatum Nothing (L.lovelaceValueOf 6_000_000)]
+      validateTxSkel def $ txSkel [PaysScript bValidator BDatum Nothing (L.lovelaceValueOf 7_000_000)]
+      validateTxSkel def $ txSkel [PaysScript bValidator BDatum Nothing (L.lovelaceValueOf 8_000_000)]
 
 tests :: TestTree
 tests =

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -79,7 +79,7 @@ test-suite spec
       Paths_examples
   hs-source-dirs:
       tests
-  ghc-options: -threaded -rtsopts
+  ghc-options: -threaded
   build-depends:
       QuickCheck
     , aeson

--- a/examples/examples.cabal
+++ b/examples/examples.cabal
@@ -79,7 +79,7 @@ test-suite spec
       Paths_examples
   hs-source-dirs:
       tests
-  ghc-options: -threaded
+  ghc-options: -threaded -rtsopts
   build-depends:
       QuickCheck
     , aeson

--- a/examples/src/Auction/Offchain.hs
+++ b/examples/src/Auction/Offchain.hs
@@ -45,7 +45,7 @@ txOpen p = do
             token,
           SpendsPK utxo
         ]
-          :=>: [ PaysScript (A.auctionValidator p') A.NoBids (A.lot p' <> token)
+          :=>: [ PaysScript (A.auctionValidator p') A.NoBids Nothing (A.lot p' <> token)
                ]
   return (p', q)
 
@@ -71,7 +71,7 @@ txBid p bid = do
             (A.Bid (A.BidderInfo bid bidder))
             utxo
         ]
-          :=>: ( [ PaysScript (A.auctionValidator p) (A.Bidding (A.BidderInfo bid bidder)) $
+          :=>: ( [ PaysScript (A.auctionValidator p) (A.Bidding (A.BidderInfo bid bidder)) Nothing $
                      A.lot p <> Ada.lovelaceValueOf bid <> Value.assetClassValue (A.threadTokenAssetClass p) 1
                  ]
                    <> case previousBidder datum of

--- a/examples/src/Split/OffChain.hs
+++ b/examples/src/Split/OffChain.hs
@@ -36,6 +36,7 @@ txLock script datum =
       [ PaysScript
           script
           datum
+          Nothing
           (Pl.lovelaceValueOf (Split.amount datum))
       ]
 

--- a/examples/tests/PMultiSigStatefulSpec.hs
+++ b/examples/tests/PMultiSigStatefulSpec.hs
@@ -96,6 +96,7 @@ mkProposal reqSigs pmt = do
                      PaysScript
                        (pmultisig params)
                        (Accumulator pmt [])
+                       Nothing
                        (minAda <> paymentValue pmt <> threadToken)
                    ]
           )
@@ -116,7 +117,7 @@ mkSign params pmt sk = do
     validateTxConstrOpts
       def
       (def {adjustUnbalTx = True})
-      [PaysScript (pmultisig params) (Sign pkh sig) mkSignLockedCost]
+      [PaysScript (pmultisig params) (Sign pkh sig) Nothing mkSignLockedCost]
   where
     sig = Pl.sign (Pl.sha2_256 $ packPayment pmt) sk ""
 
@@ -140,6 +141,7 @@ mkCollect thePayment params = signs (wallet 1) $ do
         :=>: [ PaysScript
                  (pmultisig params)
                  (Accumulator thePayment (signPk . snd <$> signatures))
+                 Nothing
                  (paymentValue thePayment <> sOutValue initialProp <> signatureValues)
              ]
 
@@ -355,6 +357,7 @@ mkFakeCollect thePayment params = do
         :=>: [ PaysScript
                  fakeValidator
                  (HJ.Accumulator (trPayment thePayment) (signPk . snd <$> signatures))
+                 Nothing
                  (paymentValue thePayment <> sOutValue initialProp <> signatureValues)
              ]
 

--- a/examples/tests/SplitSpec.hs
+++ b/examples/tests/SplitSpec.hs
@@ -46,6 +46,7 @@ txUnlock' mRecipient1 mRecipient2 mAmountChanger issuer = do
         PaysScript
           Split.splitValidator
           (Split.SplitDatum r1 r2 remainder)
+          Nothing
           (Pl.lovelaceValueOf remainder)
   void $
     validateTxConstrLbl

--- a/examples/tests/UseCaseCrowdfundingSpec.hs
+++ b/examples/tests/UseCaseCrowdfundingSpec.hs
@@ -81,7 +81,7 @@ paysCampaign c w val =
       validateTxConstrOpts
         def
         (def {autoSlotIncrease = False})
-        [PaysScript (typedValidator c) (Ledger.PaymentPubKeyHash (walletPKHash w)) val]
+        [PaysScript (typedValidator c) (Ledger.PaymentPubKeyHash (walletPKHash w)) Nothing val]
 
 -- | Retrieve funds as being the owner
 retrieveFunds :: (MonadMockChain m) => Ledger.POSIXTime -> Campaign -> Wallet -> m ()


### PR DESCRIPTION
- [x] Patch `utxosSuchThat` in `Monad.Direct` to only consider addressCredential when searching for utxos
- [x] Remove profiling directives in test examples
- [x] Adjust test cases to consider staking credential for PaysScripts